### PR TITLE
feat(datetime): Standardize frontend-backend date communication

### DIFF
--- a/backend/movies/views.py
+++ b/backend/movies/views.py
@@ -158,24 +158,30 @@ class Night(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request, format=None):
-        date = request.GET.get('date', None)
+        start_date_str = request.GET.get('start_date')
+        end_date_str = request.GET.get('end_date')
 
-        if date:
-            parsed_date = parser.parse(date)
-            movie_night = MovieNight.objects.get(night_date__date=parsed_date)
+        if start_date_str and end_date_str:
+            start_date = parse_datetime(start_date_str)
+            end_date = parse_datetime(end_date_str)
+            movie_night = MovieNight.objects.filter(night_date__range=(start_date, end_date)).first()
 
-            if movie_night.selected_movie:
-                selected_movie = serializers.serialize('python', [movie_night.selected_movie, ])[0]['fields']
+            if movie_night:
+                if movie_night.selected_movie:
+                    selected_movie = serializers.serialize('python', [movie_night.selected_movie, ])[0]['fields']
+                else:
+                    selected_movie = None
+
+                nights_response = {
+                    "host": movie_night.host,
+                    "night_date": movie_night.night_date.isoformat(),
+                    "location": movie_night.location,
+                    "selected_movie": selected_movie,
+                }
+                return HttpResponse(json.dumps([nights_response], cls=DjangoJSONEncoder),
+                                    content_type='application/json')
             else:
-                selected_movie = None
-
-            nights_response = {
-                "host": movie_night.host,
-                "night_date": date,
-                "location": movie_night.location,
-                "selected_movie": selected_movie,
-            }
-            return HttpResponse(json.dumps([nights_response], cls=DjangoJSONEncoder), content_type='application/json')
+                return HttpResponse(json.dumps([], cls=DjangoJSONEncoder), content_type='application/json')
         else:
             all_nights = serializers.serialize('python', MovieNight.objects.all())
 
@@ -189,8 +195,10 @@ class Night(APIView):
 
         try:
             night_date = parse_datetime(night_from_body.get('night_date'))
-            if MovieNight.objects.filter(night_date__date=night_date.date()).exists():
-                return HttpResponse(json.dumps({'error': 'A MovieNight already exists for this date.'}), status=400)
+            utc_date = night_date.astimezone(datetime.timezone.utc).date()
+            if MovieNight.objects.filter(night_date__date=utc_date).exists():
+                return HttpResponse(json.dumps({'error': 'A MovieNight already exists on this calendar day (UTC).'}),
+                                    status=400)
 
             new_movie_night = MovieNight(**night_from_body)
         except TypeError:

--- a/frontend/src/components/newMovieNightForm.tsx
+++ b/frontend/src/components/newMovieNightForm.tsx
@@ -39,10 +39,15 @@ export const NewMovieNightForm: FC<MovieDateProps> = ({
           onSubmit={(e) => {
             e.preventDefault();
             const target = e.currentTarget;
+            const combinedDateTime = dayjs(movieDate)
+              .hour(dayjs(nightTime).hour())
+              .minute(dayjs(nightTime).minute())
+              .second(0)
+              .millisecond(0);
+
             postMovieNight(
               getUsername() as string,
-              dayjs(movieDate).format("YYYY-MM-DD ") +
-                dayjs(nightTime).format("HH:mm"),
+              combinedDateTime.toISOString(),
               target.location.value,
             );
           }}

--- a/frontend/src/connections/internal/movieNight.ts
+++ b/frontend/src/connections/internal/movieNight.ts
@@ -26,8 +26,10 @@ export async function getMovieNight(
 ): Promise<MovieNight[]> {
   const config: AxiosRequestConfig = getAuthHeadersConfig(false);
   if (nightDate !== null) {
+    const localDay = dayjs(nightDate);
     config["params"] = {
-      date: nightDate.toLocaleDateString(),
+      start_date: localDay.startOf("day").toISOString(),
+      end_date: localDay.endOf("day").toISOString(),
     };
   }
   const response = await axios.get<MovieNight[]>(


### PR DESCRIPTION
This commit resolves a critical bug where movie nights were being scheduled on incorrect dates due to ambiguous date formats and a lack of timezone handling. All date-time communication between the frontend and backend now uses the ISO 8601 standard.

Frontend Changes:
- `movieNightAttend`: join button now refreshes on click
- `newMovieNightForm.tsx`: When creating a new movie night, the date and time are combined and sent as a full ISO 8601 string.
- `movieNight.ts`: When fetching movie nights for a specific day, the request now sends a UTC date range (`start_date`, `end_date`) to precisely define the day in the user's local timezone.
- `movieNightAttend.tsx`: The `accept_date` sent when a user joins a movie night is now a full ISO 8601 string.

Backend Changes:
- `views.py`: The `Night.get` endpoint now correctly parses the `start_date` and `end_date` parameters to filter for movie nights within the specified range.
- `views.py`: The business logic in `Night.post` that prevents creating multiple movie nights on the same day has been fixed. The check is now anchored to a consistent UTC calendar day, preventing timezone-related conflicts.
- `views.py`: Fixed a runtime `AttributeError` by replacing a call to the non-existent `timezone.utc` with the correct `datetime.timezone.utc`.